### PR TITLE
Set errno to ENOSPC when denying the STOR command

### DIFF
--- a/mod_diskuse.c
+++ b/mod_diskuse.c
@@ -287,6 +287,7 @@ MODRET diskuse_pre_stor(cmd_rec *cmd) {
       cmd->argv[0], session.user, (1.0 - min_diskfree),
       (1.0 - current_diskfree));
     pr_response_add_err(R_552, _("Insufficient disk space"));
+    errno = ENOSPC;
     return PR_ERROR(cmd);
   }
 


### PR DESCRIPTION
This allows mod_sftp to provide a better error than the generic "permission denied" (mod_sftp/fxp.c)
